### PR TITLE
ci: replace LFS images with blanks for non deployed builds

### DIFF
--- a/.github/actions/build-showcase-website/action.yml
+++ b/.github/actions/build-showcase-website/action.yml
@@ -12,6 +12,20 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: mfinelli/setup-imagemagick@v6
+      with:
+        cache: true
+
+    - name: Download LFS images
+      if: inputs.DOCKER_REGISTRY != ''
+      shell: bash
+      run: git lfs pull --include "showcase-website/**"
+
+    - name: Replace lfs images with blanks to save space
+      if: inputs.DOCKER_REGISTRY == ''
+      shell: bash
+      run: ./scripts/replace-images-with-blanks.sh
+
     - name: Docker meta
       if: inputs.DOCKER_REGISTRY != ''
       id: meta

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Detect Changes
         id: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Detect Changes
         id: changes

--- a/scripts/replace-images-with-blanks.sh
+++ b/scripts/replace-images-with-blanks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Generate the blanks images once
+magick -size 320x280 label:BLANK /tmp/blank.jpg
+magick -size 320x280 label:BLANK /tmp/blank.png
+
+# Replace LFS-tracked jpg and png files with the blank versions
+for file in $(git lfs ls-files -n); do
+    ext="${file##*.}"
+    if [[ "$ext" == "jpg" ]]; then
+        cp /tmp/blank.jpg "$file"
+    elif [[ "$ext" == "png" ]]; then
+        cp /tmp/blank.png "$file"
+    fi
+done


### PR DESCRIPTION
ci: replace LFS images with blanks for non deployed builds

 - Optimizes CI by replacing images with space-saving blanks
 - Removes redundant LFS checkout from workflows
 - Adds script to replace tracked images with placeholder files
 - Uses composite runs for efficient image processing
 - Reduces storage overhead in build environments